### PR TITLE
Adjust tax rates for GST-only provinces

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -8,16 +8,17 @@
 export const TAX_RATES = {
   'ON': 0.13,
   'QC': 0.14975,
-  'BC': 0.12,
+  // GST only in all provinces except ON and QC
+  'BC': 0.05,
   'AB': 0.05,
-  'MB': 0.12,
-  'NB': 0.15,
-  'NL': 0.15,
-  'NS': 0.15,
+  'MB': 0.05,
+  'NB': 0.05,
+  'NL': 0.05,
+  'NS': 0.05,
   'NT': 0.05,
   'NU': 0.05,
-  'PE': 0.15,
-  'SK': 0.11,
+  'PE': 0.05,
+  'SK': 0.05,
   'YT': 0.05
 };
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -12,6 +12,13 @@ describe('Calculation functions', () => {
     expect(calculateDepositCredit(deposit, taxRate)).toBeCloseTo(88.50, 2);
   });
 
+  it('uses GST-only rate for BC', () => {
+    const deposit = 100;
+    const taxRate = TAX_RATES['BC'];
+    expect(taxRate).toBeCloseTo(0.05, 2);
+    expect(calculateDepositCredit(deposit, taxRate)).toBeCloseTo(95.24, 2);
+  });
+
   it('calculates rental payment credit for less than 3 months rented', () => {
     const monthlyPayment = 50;
     const monthsRented = 2;
@@ -158,6 +165,30 @@ describe('calculateBalanceOwing', () => {
     expect(totalCredit).toBe('$186.98');
     expect(balanceOwing).toBe('$813.02');
     expect(balanceOwingWithTax).toBe('$934.77'); // Including 14.975% tax
+  });
+
+  it('calculates correctly for a GST-only province (BC)', () => {
+    const provinceSelect = document.getElementById('province');
+    provinceSelect.innerHTML = '';
+    const option = document.createElement('option');
+    option.value = 'BC';
+    option.textContent = 'BC (5%)';
+    provinceSelect.appendChild(option);
+
+    const event = { preventDefault: vi.fn() };
+    calculateBalanceOwing(event);
+
+    const rentalPaymentCredit = document.getElementById('rentalPaymentCredit').textContent;
+    const depositCredit = document.getElementById('depositCredit').textContent;
+    const totalCredit = document.getElementById('totalCredit').textContent;
+    const balanceOwing = document.getElementById('balanceOwing').textContent;
+    const balanceOwingWithTax = document.getElementById('balanceOwingWithTax').textContent;
+
+    expect(depositCredit).toBe('$95.24'); // deposit pre-tax with 5% GST
+    expect(rentalPaymentCredit).toBe('(100%) $100.00');
+    expect(totalCredit).toBe('$195.24');
+    expect(balanceOwing).toBe('$804.76');
+    expect(balanceOwingWithTax).toBe('$845.00');
   });
 
 


### PR DESCRIPTION
## Summary
- update TAX_RATES so only ON and QC have PST
- add unit test verifying BC uses GST only
- test calculation path for GST-only province

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406c2bcdac833090107994c7d404d3