### PR TITLE
Adjust CI to deploy only on push

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,6 +34,7 @@ jobs:
         run: npm test
 
   deploy:
+    if: github.event_name == 'push'
     needs: build-and-test
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- modify `deploy` job so it only runs on push events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407c7c3d7c8330ae81c32021b86431